### PR TITLE
Update github.com/thepwagner/action-update from v0.0.7 to v0.0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/moby/buildkit v0.7.2
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
-	github.com/thepwagner/action-update v0.0.7
+	github.com/thepwagner/action-update v0.0.8
 	github.com/thepwagner/action-update-docker v0.0.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/thepwagner/action-update v0.0.7 h1:9NsXwDaT7ZQiXKEpp+caixVIWitFeL00ARJ2BYrQ49s=
 github.com/thepwagner/action-update v0.0.7/go.mod h1:jqyo3EX+GsD47MjWU6s98s/8iQ08IEp9MbvkGJM+txw=
+github.com/thepwagner/action-update v0.0.8 h1:PrnqiespyGWr8slA3EOk+FBgYzKziuki24mPJXCSm60=
+github.com/thepwagner/action-update v0.0.8/go.mod h1:VrGP6NoWBhpwicDG4nqiw9XlkuwmrjLb1FaJQTbLi1I=
 github.com/thepwagner/action-update-docker v0.0.3 h1:tT41H7dpM2wA+EmFZn6uY2JM1Jyunm1QhQkACnhWaLk=
 github.com/thepwagner/action-update-docker v0.0.3/go.mod h1:ziBIeuHeZ4TYSL4rt/CSumyYhoTXjdL3LLXdyfHR078=
 github.com/tonistiigi/fsutil v0.0.0-20200326231323-c2c7d7b0e144/go.mod h1:0G1sLZ/0ttFf09xvh7GR4AEECnjifHRNJN/sYbLianU=

--- a/vendor/github.com/thepwagner/action-update/updater/group.go
+++ b/vendor/github.com/thepwagner/action-update/updater/group.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/semver"
+	"golang.org/x/mod/semver"
 )
 
 type Group struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -103,7 +103,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thepwagner/action-update v0.0.7
+# github.com/thepwagner/action-update v0.0.8
 ## explicit
 github.com/thepwagner/action-update/actions
 github.com/thepwagner/action-update/actions/updateaction


### PR DESCRIPTION
Here is github.com/thepwagner/action-update v0.0.8, I hope it works.

<!--::action-update-go::
{"updates":[{"path":"github.com/thepwagner/action-update","previous":"v0.0.7","next":"v0.0.8"}],"signature":"/I1B4XZ6iC600ussGfppx/wamAT96RtjDKJyS/0ouMnDBmxH67qQVJASTxG4yYE2HuWbCIHSoEqQQvvUYzCNbg=="}
-->