### PR TITLE
Update golangci/golangci-lint from v1.32.0-alpine to v1.32.2-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.32.0-alpine
+FROM golangci/golangci-lint:v1.32.2-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.32.2-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.32.0-alpine","next":"v1.32.2-alpine"}]},"signature":"KY4rz7XuNQra9mDCQ/UkJkTfselykGqvb7a+cu3kVqUT66ir52cWe4+ijfoAdDNKuDao+jBphYKNt+RF3RZtzw=="}
-->