### PR TITLE
Update golang from 1.15.4 to 1.15.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.4'
+        go-version: '1.15.5'
     - run: script/test
     - run: script/lint

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.MY_GITHUB_PAT }}
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.4'
+          go-version: '1.15.5'
       - run: git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_PAT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.4 AS builder
+FROM golang:1.15.5 AS builder
 
 WORKDIR /app
 COPY go.mod /app


### PR DESCRIPTION
Here is golang 1.15.5, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.15.4","next":"1.15.5"}]},"signature":"h3Nd98kf871JI9qUzWVQHUF9Q+zZ8H4wz8A+BF9Qp7aYjQe7yz63AecgUhg/KAJJOET9YZBJMDObFKdr5lEYRg=="}
-->