### PR TITLE
Update github.com/thepwagner/action-update from  to v0.0.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/moby/buildkit v0.8.0-rc2
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
-	github.com/thepwagner/action-update v0.0.26
+	github.com/thepwagner/action-update v0.0.27
 	github.com/thepwagner/action-update-docker v0.0.7
 	golang.org/x/mod v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar/v2 v2.0.3 h1:D6SI8MzWzXXBXZFS87cFL6s/n307lEU+thM2SUnge3g=
 github.com/bmatcuk/doublestar/v2 v2.0.3/go.mod h1:QMmcs3H2AUQICWhfzLXz+IYln8lRQmTZRptLie8RgRw=
+github.com/bmatcuk/doublestar/v2 v2.0.4 h1:6I6oUiT/sU27eE2OFcWqBhL1SwjyvQuOssxT4a1yidI=
+github.com/bmatcuk/doublestar/v2 v2.0.4/go.mod h1:QMmcs3H2AUQICWhfzLXz+IYln8lRQmTZRptLie8RgRw=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
@@ -970,6 +972,8 @@ github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQx
 github.com/tetafro/godot v0.4.2/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/thepwagner/action-update v0.0.26 h1:4Zw2WHaZB26V+3cbRQGjGk6tcK+RIVX0fgVe1nMnlEw=
 github.com/thepwagner/action-update v0.0.26/go.mod h1:2lUx9ybD0qJrfpZWzPvm2pHmfuuS86An7R3UTNq+prM=
+github.com/thepwagner/action-update v0.0.27 h1:5wZCtYJU6jLX1ypTIXtTc3l0QH8QJM3QqQlYHnBvkFs=
+github.com/thepwagner/action-update v0.0.27/go.mod h1:fYlNdEIgTv2uZf0n4Dk5+p17v7bjxYhw07lHR2ENXTw=
 github.com/thepwagner/action-update-docker v0.0.7 h1:uQ/FQLwTBVt/BdDrvAbR/P4jBcpkANIXwZ2gTjupelA=
 github.com/thepwagner/action-update-docker v0.0.7/go.mod h1:LWwI01nmvn/Q5p6yr3VhsoQYzKP09XQrZgNkvtOgMis=
 github.com/theupdateframework/notary v0.6.1 h1:7wshjstgS9x9F5LuB1L5mBI2xNMObWqjz+cjWoom6l0=

--- a/vendor/github.com/bmatcuk/doublestar/v2/README.md
+++ b/vendor/github.com/bmatcuk/doublestar/v2/README.md
@@ -107,6 +107,10 @@ Special Terms | Meaning
 
 Any character with a special meaning can be escaped with a backslash (`\`).
 
+A mid-pattern doublestar (`**`) behaves like bash's globstar option: a pattern
+such as `path/to/**.txt` would return the same results as `path/to/*.txt`. The
+pattern you're looking for is `path/to/**/*.txt`.
+
 #### Character Classes
 
 Character classes support the following:

--- a/vendor/github.com/bmatcuk/doublestar/v2/doublestar.go
+++ b/vendor/github.com/bmatcuk/doublestar/v2/doublestar.go
@@ -305,7 +305,7 @@ func GlobOS(vos OS, pattern string) (matches []string, err error) {
 			return nil, ErrBadPattern
 		}
 		for _, o := range options {
-			m, e := Glob(o + pattern[endOptions+1:])
+			m, e := GlobOS(vos, o+pattern[endOptions+1:])
 			if e != nil {
 				return nil, e
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/agl/ed25519
 github.com/agl/ed25519/edwards25519
 # github.com/beorn7/perks v1.0.0
 github.com/beorn7/perks/quantile
-# github.com/bmatcuk/doublestar/v2 v2.0.3
+# github.com/bmatcuk/doublestar/v2 v2.0.4
 github.com/bmatcuk/doublestar/v2
 # github.com/caarlos0/env/v6 v6.4.0
 github.com/caarlos0/env/v6
@@ -254,7 +254,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thepwagner/action-update v0.0.26
+# github.com/thepwagner/action-update v0.0.27
 ## explicit
 github.com/thepwagner/action-update/actions
 github.com/thepwagner/action-update/actions/updateaction


### PR DESCRIPTION
Here is github.com/thepwagner/action-update v0.0.27, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/thepwagner/action-update","previous":"","next":"v0.0.27"}]},"signature":"4y7jpES80BM8ihtwy8TTvXUAcmNINyM2aTj0xizw80/5n05GpMv9T/2bfbojM1/xyshH8ySIwZcoDWPkce/OQQ=="}
-->