### PR TITLE
Update github.com/thepwagner/action-update from v0.0.27 to v0.0.28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/moby/buildkit v0.8.0-rc2
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
-	github.com/thepwagner/action-update v0.0.27
+	github.com/thepwagner/action-update v0.0.28
 	github.com/thepwagner/action-update-docker v0.0.7
 	golang.org/x/mod v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -972,8 +972,8 @@ github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQx
 github.com/tetafro/godot v0.4.2/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/thepwagner/action-update v0.0.26 h1:4Zw2WHaZB26V+3cbRQGjGk6tcK+RIVX0fgVe1nMnlEw=
 github.com/thepwagner/action-update v0.0.26/go.mod h1:2lUx9ybD0qJrfpZWzPvm2pHmfuuS86An7R3UTNq+prM=
-github.com/thepwagner/action-update v0.0.27 h1:5wZCtYJU6jLX1ypTIXtTc3l0QH8QJM3QqQlYHnBvkFs=
-github.com/thepwagner/action-update v0.0.27/go.mod h1:fYlNdEIgTv2uZf0n4Dk5+p17v7bjxYhw07lHR2ENXTw=
+github.com/thepwagner/action-update v0.0.28 h1:503klKa9TbArCObpzZwkD9DV+FjW0u0dOU+VuK6LmEc=
+github.com/thepwagner/action-update v0.0.28/go.mod h1:fYlNdEIgTv2uZf0n4Dk5+p17v7bjxYhw07lHR2ENXTw=
 github.com/thepwagner/action-update-docker v0.0.7 h1:uQ/FQLwTBVt/BdDrvAbR/P4jBcpkANIXwZ2gTjupelA=
 github.com/thepwagner/action-update-docker v0.0.7/go.mod h1:LWwI01nmvn/Q5p6yr3VhsoQYzKP09XQrZgNkvtOgMis=
 github.com/theupdateframework/notary v0.6.1 h1:7wshjstgS9x9F5LuB1L5mBI2xNMObWqjz+cjWoom6l0=

--- a/vendor/github.com/thepwagner/action-update/actions/handlers.go
+++ b/vendor/github.com/thepwagner/action-update/actions/handlers.go
@@ -99,11 +99,11 @@ func (h *Handlers) handler(event string) func(context.Context, interface{}) erro
 		}
 
 	case "workflow_dispatch":
-		if h.Schedule == nil {
+		if h.WorkflowDispatch == nil {
 			return nil
 		}
 		return func(ctx context.Context, _ interface{}) error {
-			return h.Schedule(ctx)
+			return h.WorkflowDispatch(ctx)
 		}
 
 	default:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -254,7 +254,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thepwagner/action-update v0.0.27
+# github.com/thepwagner/action-update v0.0.28
 ## explicit
 github.com/thepwagner/action-update/actions
 github.com/thepwagner/action-update/actions/updateaction


### PR DESCRIPTION
Here is github.com/thepwagner/action-update v0.0.28, I hope it works.

<!--::action-update-go::
{"signed":{"name":"internal","updates":[{"path":"github.com/thepwagner/action-update","previous":"v0.0.27","next":"v0.0.28"}]},"signature":"3ecqE2JkZcV1iNF6b6gbZhPvvQoc2PO2AtObAHDpIVHV9duNtsSEBobYQ9UEEVykT6jin1c/kc75UBREpLi1Ng=="}
-->