### PR TITLE
Update github.com/moby/buildkit from v0.8.0 to v0.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/google/go-github/v33 v33.0.0
-	github.com/moby/buildkit v0.8.0
+	github.com/moby/buildkit v0.8.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
 	github.com/thepwagner/action-update v0.0.30

--- a/go.sum
+++ b/go.sum
@@ -727,8 +727,8 @@ github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f h1:2+myh5ml7lgEU/5
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/buildkit v0.8.0-rc1 h1:Dxir4+oeB2kG8/qbcLKZsXsZZ3WhIZjuV0AXQEfJWwo=
 github.com/moby/buildkit v0.8.0-rc1/go.mod h1:dfC1O0+sj4R9jCjf5OQo/IeGEQzSS9pTFIBL8fV1W3U=
-github.com/moby/buildkit v0.8.0 h1:tISWRE91AC65sGDgnaHwSS3AVBr62zTWdDORlWq1HBw=
-github.com/moby/buildkit v0.8.0/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=
+github.com/moby/buildkit v0.8.1 h1:zrGxLwffKM8nVxBvaJa7H404eQLfqlg1GB6YVIzXVQ0=
+github.com/moby/buildkit v0.8.1/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/moby v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible h1:zTnM9zBtyWn5qBGVVhhbGYIWVsYtiuEZPHSctpjbrGg=
 github.com/moby/moby v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -201,7 +201,7 @@ github.com/matttproud/golang_protobuf_extensions/pbutil
 github.com/miekg/pkcs11
 # github.com/mitchellh/go-homedir v1.1.0
 github.com/mitchellh/go-homedir
-# github.com/moby/buildkit v0.8.0
+# github.com/moby/buildkit v0.8.1
 ## explicit
 github.com/moby/buildkit/frontend/dockerfile/command
 github.com/moby/buildkit/frontend/dockerfile/parser


### PR DESCRIPTION
Here is github.com/moby/buildkit v0.8.1, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/moby/buildkit","previous":"v0.8.0","next":"v0.8.1"}]},"signature":"PNIKH+kAdPN5ZG5HxDWdliKlFa94hgzNyf1h+jw4jrLi58nvrOI7Y3YX4ud2xyFxqbhNKoakviuq7Vg0C+Rdkw=="}
-->