### PR TITLE
Update golangci/golangci-lint from v1.33.0-alpine to v1.34.1-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.33.0-alpine
+FROM golangci/golangci-lint:v1.34.1-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.34.1-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.33.0-alpine","next":"v1.34.1-alpine"}]},"signature":"BRw6oncN+TkFySR66FP1F0FbOuY56uK4hi7RXwq30VBiluyl4j/GMvoQXpzTcGqZ5oa4dXqzihXti6Qe5oLuhw=="}
-->