### PR TITLE
Update golangci/golangci-lint from v1.34.1-alpine to v1.35.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.34.1-alpine
+FROM golangci/golangci-lint:v1.35.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.35.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.34.1-alpine","next":"v1.35.0-alpine"}]},"signature":"IPC8kZlQsgZYdMl2Ty9FV37NiISqlmbpOcyVkmM0JMi8WVRksXhyn2XTDtQR08+KgV5+FuHxikrAJatZ6p/N1g=="}
-->