### PR TITLE
Update github.com/thepwagner/action-update from  to v0.0.38

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/moby/buildkit v0.8.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0
-	github.com/thepwagner/action-update v0.0.37
+	github.com/thepwagner/action-update v0.0.38
 	github.com/thepwagner/action-update-docker v0.0.8
 	golang.org/x/mod v0.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3k
 github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGrrHhcQw=
 github.com/caarlos0/env/v6 v6.4.0 h1:fUo2hQNR3O7Yb7E2sYy8cxY42BRvFxWa0G4XBMLJAQM=
 github.com/caarlos0/env/v6 v6.4.0/go.mod h1:MX/8qQ2zCofGGkb7FxjmDLOOjUylO2b7dbsIpN30bnY=
+github.com/caarlos0/env/v6 v6.5.0 h1:f4C7ZQwm0nRFo8vETCQviLUOtOlOwsOhgc/QXp0zrTM=
+github.com/caarlos0/env/v6 v6.5.0/go.mod h1:5ZqhjfyF261xGkANuSuMQ1FeA9ikA3wzDY64wSd9k8k=
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
@@ -970,8 +972,8 @@ github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQx
 github.com/tetafro/godot v0.4.2/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/thepwagner/action-update v0.0.31 h1:bCRbzpKEJ0o01YcA2n74pj+MY1FGNS3a3VSIEYdwgek=
 github.com/thepwagner/action-update v0.0.31/go.mod h1:6FCNUGnul4Flbg9OiQYeOlHlKky9TK5Pfl9u0nc0/Ww=
-github.com/thepwagner/action-update v0.0.37 h1:LrGXoG8BHwOgMhEUqD/t2n+oIrLwiUV1vmjpVuekaCg=
-github.com/thepwagner/action-update v0.0.37/go.mod h1:6FCNUGnul4Flbg9OiQYeOlHlKky9TK5Pfl9u0nc0/Ww=
+github.com/thepwagner/action-update v0.0.38 h1:uO6eYArYqBDxrs0BzENf2/JmmtA+hd//oBFqmlNgjjw=
+github.com/thepwagner/action-update v0.0.38/go.mod h1:6vWEcGqSeVrxi9Tp90ao3g/bXsx5iShZuqj8JdvKB8M=
 github.com/thepwagner/action-update-docker v0.0.8 h1:jloJDJ05k8N61Xfu+CMfz8U1FsvWMywZQ1XNjd8tO3U=
 github.com/thepwagner/action-update-docker v0.0.8/go.mod h1:rH+CDu7Ail9uNWLVn9G5Lz7rorkYfC2rYxk1QPlY3yY=
 github.com/theupdateframework/notary v0.6.1 h1:7wshjstgS9x9F5LuB1L5mBI2xNMObWqjz+cjWoom6l0=

--- a/vendor/github.com/caarlos0/env/v6/README.md
+++ b/vendor/github.com/caarlos0/env/v6/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://img.shields.io/github/workflow/status/caarlos0/env/build?style=for-the-badge)](https://github.com/caarlos0/env/actions?workflow=build)
 [![Coverage Status](https://img.shields.io/codecov/c/gh/caarlos0/env.svg?logo=codecov&style=for-the-badge)](https://codecov.io/gh/caarlos0/env)
-[![](http://img.shields.io/badge/godoc-reference-5272B4.svg?style=for-the-badge)](http://godoc.org/github.com/caarlos0/env)
+[![](http://img.shields.io/badge/godoc-reference-5272B4.svg?style=for-the-badge)](http://godoc.org/github.com/caarlos0/env/v6)
 
 Simple lib to parse envs to structs in Go.
 

--- a/vendor/github.com/caarlos0/env/v6/env.go
+++ b/vendor/github.com/caarlos0/env/v6/env.go
@@ -280,7 +280,7 @@ func getFromFile(filename string) (value string, err error) {
 func getOr(key, defaultValue string, defExists bool, envs map[string]string) (value string, exists bool) {
 	value, exists = envs[key]
 	switch {
-	case !exists && defExists:
+	case (!exists || key == "") && defExists:
 		return defaultValue, true
 	case !exists:
 		return "", false

--- a/vendor/github.com/caarlos0/env/v6/go.mod
+++ b/vendor/github.com/caarlos0/env/v6/go.mod
@@ -1,5 +1,5 @@
 module github.com/caarlos0/env/v6
 
-require github.com/stretchr/testify v1.6.1
+require github.com/stretchr/testify v1.7.0
 
 go 1.14

--- a/vendor/github.com/caarlos0/env/v6/go.sum
+++ b/vendor/github.com/caarlos0/env/v6/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/vendor/github.com/thepwagner/action-update/updater/branch.go
+++ b/vendor/github.com/thepwagner/action-update/updater/branch.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"path"
+	"strings"
 )
 
 const branchPrefix = "action-update-go"
@@ -19,7 +20,12 @@ type DefaultUpdateBranchNamer struct{}
 var _ UpdateBranchNamer = (*DefaultUpdateBranchNamer)(nil)
 
 func (d DefaultUpdateBranchNamer) Format(baseBranch string, update Update) string {
-	return path.Join(branchPrefix, baseBranch, update.Path, update.Next)
+	cleanPath := strings.ReplaceAll(update.Path, "https://", "")
+	cleanPath = strings.ReplaceAll(cleanPath, "http://", "")
+	cleanPath = strings.ReplaceAll(cleanPath, "#", "")
+	cleanPath = strings.ReplaceAll(cleanPath, "{", "")
+	cleanPath = strings.ReplaceAll(cleanPath, "}", "")
+	return path.Join(branchPrefix, baseBranch, cleanPath, update.Next)
 }
 
 func (d DefaultUpdateBranchNamer) FormatBatch(baseBranch, batchName string) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/agl/ed25519/edwards25519
 github.com/beorn7/perks/quantile
 # github.com/bmatcuk/doublestar/v3 v3.0.0
 github.com/bmatcuk/doublestar/v3
-# github.com/caarlos0/env/v6 v6.4.0
+# github.com/caarlos0/env/v6 v6.5.0
 github.com/caarlos0/env/v6
 # github.com/containerd/containerd v1.4.1-0.20201117152358-0edc412565dc => github.com/containerd/containerd v1.4.0
 github.com/containerd/containerd/errdefs
@@ -254,7 +254,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thepwagner/action-update v0.0.37
+# github.com/thepwagner/action-update v0.0.38
 ## explicit
 github.com/thepwagner/action-update/actions
 github.com/thepwagner/action-update/actions/updateaction


### PR DESCRIPTION
Here is github.com/thepwagner/action-update v0.0.38, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/thepwagner/action-update","previous":"","next":"v0.0.38"}]},"signature":"rJN3oKjKaWADBKr5HEq6FIZzV75OoB0Cf1BRsUgBQBgbHL1HEKrE0KCkcrHG8SP4l89gJe9IblF2WaKWAHRxXA=="}
-->