### PR TITLE
Update golang from 1.16.1 to 1.16.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,6 @@ jobs:
           ${{ runner.os }}-go-
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.16.1'
+        go-version: '1.16.2'
     - run: script/test
     - run: script/lint

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -22,7 +22,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.1'
+          go-version: '1.16.2'
       - run: git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
         env:
           GITHUB_TOKEN: ${{ secrets.MY_GITHUB_PAT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.1 AS builder
+FROM golang:1.16.2 AS builder
 
 WORKDIR /app
 COPY go.mod /app


### PR DESCRIPTION
Here is golang 1.16.2, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.16.1","next":"1.16.2"}]},"signature":"gvB/Noo1KI2qHOn5B+bnmmx8OJZmPqGhRH6PRAy6n9XCjmerrPacdVQPIzR0H10cFzTALZYw6ukBjdPJTBIHIQ=="}
-->