### PR TITLE
Update github.com/google/go-github/v35 from v35.0.0 to v35.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/thepwagner/action-update-dockerurl
 go 1.15
 
 require (
-	github.com/google/go-github/v35 v35.0.0
+	github.com/google/go-github/v35 v35.1.0
 	github.com/moby/buildkit v0.8.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,9 @@ github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4r
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
-github.com/google/go-github/v35 v35.0.0 h1:oLrHdYkSQvbhN4gJihpEkTFKAZnIFgTCj1p/OlE4Os4=
 github.com/google/go-github/v35 v35.0.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
+github.com/google/go-github/v35 v35.1.0 h1:KkwZnKWQ/0YryvXjZlCN/3EGRJNp6VCZPKo+RG9mG28=
+github.com/google/go-github/v35 v35.1.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=

--- a/vendor/github.com/google/go-github/v35/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/v35/github/github-accessors.go
@@ -6108,12 +6108,28 @@ func (i *IssueImportResponse) GetURL() string {
 	return *i.URL
 }
 
+// GetDirection returns the Direction field if it's non-nil, zero value otherwise.
+func (i *IssueListCommentsOptions) GetDirection() string {
+	if i == nil || i.Direction == nil {
+		return ""
+	}
+	return *i.Direction
+}
+
 // GetSince returns the Since field if it's non-nil, zero value otherwise.
 func (i *IssueListCommentsOptions) GetSince() time.Time {
 	if i == nil || i.Since == nil {
 		return time.Time{}
 	}
 	return *i.Since
+}
+
+// GetSort returns the Sort field if it's non-nil, zero value otherwise.
+func (i *IssueListCommentsOptions) GetSort() string {
+	if i == nil || i.Sort == nil {
+		return ""
+	}
+	return *i.Sort
 }
 
 // GetAssignee returns the Assignee field if it's non-nil, zero value otherwise.
@@ -13210,6 +13226,14 @@ func (r *RepositoryRelease) GetCreatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *r.CreatedAt
+}
+
+// GetDiscussionCategoryName returns the DiscussionCategoryName field if it's non-nil, zero value otherwise.
+func (r *RepositoryRelease) GetDiscussionCategoryName() string {
+	if r == nil || r.DiscussionCategoryName == nil {
+		return ""
+	}
+	return *r.DiscussionCategoryName
 }
 
 // GetDraft returns the Draft field if it's non-nil, zero value otherwise.

--- a/vendor/github.com/google/go-github/v35/github/issues_comments.go
+++ b/vendor/github.com/google/go-github/v35/github/issues_comments.go
@@ -35,6 +35,12 @@ func (i IssueComment) String() string {
 // IssueListCommentsOptions specifies the optional parameters to the
 // IssuesService.ListComments method.
 type IssueListCommentsOptions struct {
+	// Sort specifies how to sort comments. Possible values are: created, updated.
+	Sort *string `url:"sort,omitempty"`
+
+	// Direction in which to sort comments. Possible values are: asc, desc.
+	Direction *string `url:"direction,omitempty"`
+
 	// Since filters comments by time.
 	Since *time.Time `url:"since,omitempty"`
 

--- a/vendor/github.com/google/go-github/v35/github/repos_releases.go
+++ b/vendor/github.com/google/go-github/v35/github/repos_releases.go
@@ -19,12 +19,13 @@ import (
 
 // RepositoryRelease represents a GitHub release in a repository.
 type RepositoryRelease struct {
-	TagName         *string `json:"tag_name,omitempty"`
-	TargetCommitish *string `json:"target_commitish,omitempty"`
-	Name            *string `json:"name,omitempty"`
-	Body            *string `json:"body,omitempty"`
-	Draft           *bool   `json:"draft,omitempty"`
-	Prerelease      *bool   `json:"prerelease,omitempty"`
+	TagName                *string `json:"tag_name,omitempty"`
+	TargetCommitish        *string `json:"target_commitish,omitempty"`
+	Name                   *string `json:"name,omitempty"`
+	Body                   *string `json:"body,omitempty"`
+	Draft                  *bool   `json:"draft,omitempty"`
+	Prerelease             *bool   `json:"prerelease,omitempty"`
+	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
 
 	// The following fields are not used in CreateRelease or EditRelease:
 	ID          *int64          `json:"id,omitempty"`
@@ -134,12 +135,13 @@ func (s *RepositoriesService) getSingleRelease(ctx context.Context, url string) 
 // See https://github.com/google/go-github/issues/992 for more
 // information.
 type repositoryReleaseRequest struct {
-	TagName         *string `json:"tag_name,omitempty"`
-	TargetCommitish *string `json:"target_commitish,omitempty"`
-	Name            *string `json:"name,omitempty"`
-	Body            *string `json:"body,omitempty"`
-	Draft           *bool   `json:"draft,omitempty"`
-	Prerelease      *bool   `json:"prerelease,omitempty"`
+	TagName                *string `json:"tag_name,omitempty"`
+	TargetCommitish        *string `json:"target_commitish,omitempty"`
+	Name                   *string `json:"name,omitempty"`
+	Body                   *string `json:"body,omitempty"`
+	Draft                  *bool   `json:"draft,omitempty"`
+	Prerelease             *bool   `json:"prerelease,omitempty"`
+	DiscussionCategoryName *string `json:"discussion_category_name,omitempty"`
 }
 
 // CreateRelease adds a new release for a repository.
@@ -152,12 +154,13 @@ func (s *RepositoriesService) CreateRelease(ctx context.Context, owner, repo str
 	u := fmt.Sprintf("repos/%s/%s/releases", owner, repo)
 
 	releaseReq := &repositoryReleaseRequest{
-		TagName:         release.TagName,
-		TargetCommitish: release.TargetCommitish,
-		Name:            release.Name,
-		Body:            release.Body,
-		Draft:           release.Draft,
-		Prerelease:      release.Prerelease,
+		TagName:                release.TagName,
+		TargetCommitish:        release.TargetCommitish,
+		Name:                   release.Name,
+		Body:                   release.Body,
+		Draft:                  release.Draft,
+		Prerelease:             release.Prerelease,
+		DiscussionCategoryName: release.DiscussionCategoryName,
 	}
 
 	req, err := s.client.NewRequest("POST", u, releaseReq)
@@ -183,12 +186,13 @@ func (s *RepositoriesService) EditRelease(ctx context.Context, owner, repo strin
 	u := fmt.Sprintf("repos/%s/%s/releases/%d", owner, repo, id)
 
 	releaseReq := &repositoryReleaseRequest{
-		TagName:         release.TagName,
-		TargetCommitish: release.TargetCommitish,
-		Name:            release.Name,
-		Body:            release.Body,
-		Draft:           release.Draft,
-		Prerelease:      release.Prerelease,
+		TagName:                release.TagName,
+		TargetCommitish:        release.TargetCommitish,
+		Name:                   release.Name,
+		Body:                   release.Body,
+		Draft:                  release.Draft,
+		Prerelease:             release.Prerelease,
+		DiscussionCategoryName: release.DiscussionCategoryName,
 	}
 
 	req, err := s.client.NewRequest("PATCH", u, releaseReq)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,7 +180,7 @@ github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
-# github.com/google/go-github/v35 v35.0.0
+# github.com/google/go-github/v35 v35.1.0
 ## explicit
 github.com/google/go-github/v35/github
 # github.com/google/go-querystring v1.0.0


### PR DESCRIPTION
Here is github.com/google/go-github/v35 v35.1.0, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/google/go-github/v35","previous":"v35.0.0","next":"v35.1.0"}]},"signature":"CWeugoaKZnkKazcKWi2PuZJIm382G2DBqS3Yqest3m+Y/6QxeNhj0rLi2iCnxDRhQpmCwi9iAotc05C6FLBk6w=="}
-->