### PR TITLE
Update github.com/google/go-github/v35 from v35.1.0 to v35.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/thepwagner/action-update-dockerurl
 go 1.15
 
 require (
-	github.com/google/go-github/v35 v35.1.0
+	github.com/google/go-github/v35 v35.2.0
 	github.com/moby/buildkit v0.8.3
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
 github.com/google/go-github/v35 v35.0.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
-github.com/google/go-github/v35 v35.1.0 h1:KkwZnKWQ/0YryvXjZlCN/3EGRJNp6VCZPKo+RG9mG28=
-github.com/google/go-github/v35 v35.1.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
+github.com/google/go-github/v35 v35.2.0 h1:s/soW8jauhjUC3rh8JI0FePuocj0DEI9DNBg/bVplE8=
+github.com/google/go-github/v35 v35.2.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=

--- a/vendor/github.com/google/go-github/v35/github/actions_runners.go
+++ b/vendor/github.com/google/go-github/v35/github/actions_runners.go
@@ -12,10 +12,12 @@ import (
 
 // RunnerApplicationDownload represents a binary for the self-hosted runner application that can be downloaded.
 type RunnerApplicationDownload struct {
-	OS           *string `json:"os,omitempty"`
-	Architecture *string `json:"architecture,omitempty"`
-	DownloadURL  *string `json:"download_url,omitempty"`
-	Filename     *string `json:"filename,omitempty"`
+	OS                *string `json:"os,omitempty"`
+	Architecture      *string `json:"architecture,omitempty"`
+	DownloadURL       *string `json:"download_url,omitempty"`
+	Filename          *string `json:"filename,omitempty"`
+	TempDownloadToken *string `json:"temp_download_token,omitempty"`
+	SHA256Checksum    *string `json:"sha256_checksum,omitempty"`
 }
 
 // ActionsEnabledOnOrgRepos represents all the repositories in an organization for which Actions is enabled.

--- a/vendor/github.com/google/go-github/v35/github/apps_installation.go
+++ b/vendor/github.com/google/go-github/v35/github/apps_installation.go
@@ -32,7 +32,11 @@ func (s *AppsService) ListRepos(ctx context.Context, opts *ListOptions) (*ListRe
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	acceptHeaders := []string{
+		mediaTypeTopicsPreview,
+		mediaTypeRepositoryVisibilityPreview,
+		mediaTypeRepositoryTemplatePreview,
+	}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories
@@ -62,7 +66,11 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int64, opts *ListOpt
 	}
 
 	// TODO: remove custom Accept headers when APIs fully launch.
-	acceptHeaders := []string{mediaTypeTopicsPreview, mediaTypeRepositoryVisibilityPreview}
+	acceptHeaders := []string{
+		mediaTypeTopicsPreview,
+		mediaTypeRepositoryVisibilityPreview,
+		mediaTypeRepositoryTemplatePreview,
+	}
 	req.Header.Set("Accept", strings.Join(acceptHeaders, ", "))
 
 	var r *ListRepositories

--- a/vendor/github.com/google/go-github/v35/github/apps_manifest.go
+++ b/vendor/github.com/google/go-github/v35/github/apps_manifest.go
@@ -10,10 +10,6 @@ import (
 	"fmt"
 )
 
-const (
-	mediaTypeAppManifestPreview = "application/vnd.github.fury-preview+json"
-)
-
 // AppConfig describes the configuration of a GitHub App.
 type AppConfig struct {
 	ID            *int64     `json:"id,omitempty"`
@@ -41,7 +37,6 @@ func (s *AppsService) CompleteAppManifest(ctx context.Context, code string) (*Ap
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Set("Accept", mediaTypeAppManifestPreview)
 
 	cfg := new(AppConfig)
 	resp, err := s.client.Do(ctx, req, cfg)

--- a/vendor/github.com/google/go-github/v35/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/v35/github/github-accessors.go
@@ -13612,6 +13612,22 @@ func (r *RunnerApplicationDownload) GetOS() string {
 	return *r.OS
 }
 
+// GetSHA256Checksum returns the SHA256Checksum field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetSHA256Checksum() string {
+	if r == nil || r.SHA256Checksum == nil {
+		return ""
+	}
+	return *r.SHA256Checksum
+}
+
+// GetTempDownloadToken returns the TempDownloadToken field if it's non-nil, zero value otherwise.
+func (r *RunnerApplicationDownload) GetTempDownloadToken() string {
+	if r == nil || r.TempDownloadToken == nil {
+		return ""
+	}
+	return *r.TempDownloadToken
+}
+
 // GetAllowsPublicRepositories returns the AllowsPublicRepositories field if it's non-nil, zero value otherwise.
 func (r *RunnerGroup) GetAllowsPublicRepositories() bool {
 	if r == nil || r.AllowsPublicRepositories == nil {
@@ -14258,6 +14274,14 @@ func (t *Team) GetPermission() string {
 		return ""
 	}
 	return *t.Permission
+}
+
+// GetPermissions returns the Permissions field if it's non-nil, zero value otherwise.
+func (t *Team) GetPermissions() map[string]bool {
+	if t == nil || t.Permissions == nil {
+		return map[string]bool{}
+	}
+	return *t.Permissions
 }
 
 // GetPrivacy returns the Privacy field if it's non-nil, zero value otherwise.

--- a/vendor/github.com/google/go-github/v35/github/teams.go
+++ b/vendor/github.com/google/go-github/v35/github/teams.go
@@ -32,6 +32,10 @@ type Team struct {
 	// Permission specifies the default permission for repositories owned by the team.
 	Permission *string `json:"permission,omitempty"`
 
+	// Permissions identifies the permissions that a team has on a given
+	// repository. This is only populated when calling Repositories.ListTeams.
+	Permissions *map[string]bool `json:"permissions,omitempty"`
+
 	// Privacy identifies the level of privacy this team should have.
 	// Possible values are:
 	//     secret - only visible to organization owners and members of this team

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,7 +180,7 @@ github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
-# github.com/google/go-github/v35 v35.1.0
+# github.com/google/go-github/v35 v35.2.0
 ## explicit
 github.com/google/go-github/v35/github
 # github.com/google/go-querystring v1.0.0


### PR DESCRIPTION
Here is github.com/google/go-github/v35 v35.2.0, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/google/go-github/v35","previous":"v35.1.0","next":"v35.2.0"}]},"signature":"ysWXAwYDa7VWiXnmHe4EzBBKYLtHtrTA8d0/Kq9bcksVTu8WWwOG8ETVQVD0vzipEHpMmVSiq9oyGX67VWiSVw=="}
-->