### PR TITLE
Update golangci/golangci-lint from v1.40.0-alpine to v1.40.1-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.40.0-alpine
+FROM golangci/golangci-lint:v1.40.1-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.40.1-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.40.0-alpine","next":"v1.40.1-alpine"}]},"signature":"FB4G89fZgugcoW/LYku7WalPz/bf0hwfo9X7GNVDk9hwitFhTSNI5zKgdpQbdYLwaA1q3Ubm/vEr0rKgsh7hUA=="}
-->