### PR TITLE
Update golangci/golangci-lint from v1.40.1-alpine to v1.41.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.40.1-alpine
+FROM golangci/golangci-lint:v1.41.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.41.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.40.1-alpine","next":"v1.41.0-alpine"}]},"signature":"8kohq8+VkWDNql27o3cJQflvVA36MJp94kDA2t7WtvpUmdFy3NAs+ng2Fl8Rgb68IyvaMxfu9flZ0QwL7MZ+KA=="}
-->