### PR TITLE
Update golangci/golangci-lint from v1.41.0-alpine to v1.41.1-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.41.0-alpine
+FROM golangci/golangci-lint:v1.41.1-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.41.1-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golangci/golangci-lint","previous":"v1.41.0-alpine","next":"v1.41.1-alpine"}]},"signature":"UjPReHaidtZ0PjFysZ/TguFIZPNGo9wqEQLnrBUnrTiPmJqTcwjGl3Tli1BmJ7ZNz25R3po1SKZY0Yi62jfjjw=="}
-->