### PR TITLE
Update google.golang.org/grpc from v1.39.0 to v1.40.0-dev

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	google.golang.org/genproto v0.0.0-20210701191553-46259e63a0a9 // indirect
-	google.golang.org/grpc v1.39.0 // indirect
+	google.golang.org/grpc v1.40.0-dev // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -1726,8 +1726,8 @@ google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.39.0 h1:Klz8I9kdtkIN6EpHHUOMLCYhTn/2WAe5a0s1hcBkdTI=
-google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
+google.golang.org/grpc v1.40.0-dev h1:zBqtu49w/oD2rYaGdbq6uQh1wgHzjF60huzQoJPefFo=
+google.golang.org/grpc v1.40.0-dev/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -375,7 +375,7 @@ google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20210701191553-46259e63a0a9
 ## explicit
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.39.0
+# google.golang.org/grpc v1.40.0-dev
 ## explicit
 google.golang.org/grpc/codes
 google.golang.org/grpc/internal/status


### PR DESCRIPTION
Here is google.golang.org/grpc v1.40.0-dev, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"google.golang.org/grpc","previous":"v1.39.0","next":"v1.40.0-dev"}]},"signature":"LJLEZpcwlP4qoKT3buRHC2JBUC10PZm8uWSseq9DKuMbldCc4J180qIHDTDPZVMJ42m8oBiIWsjgQ3Vk2frOTA=="}
-->